### PR TITLE
Add generic thickness for ls

### DIFF
--- a/LoopProjectFile/LoopProjectFile.py
+++ b/LoopProjectFile/LoopProjectFile.py
@@ -37,6 +37,7 @@ import os
 import enum
 
 import netCDF4
+from .LoopProjectFileEnums import ThicknessCalculatorType
 import LoopProjectFile.Version as Version
 import LoopProjectFile.Extents as Extents
 import LoopProjectFile.StructuralModels as StructuralModels
@@ -44,31 +45,6 @@ import LoopProjectFile.DataCollection as DataCollection
 import LoopProjectFile.ExtractedInformation as ExtractedInformation
 import LoopProjectFile.GeophysicalModels as GeophysicalModels
 import LoopProjectFile.ProbabilityModels as ProbabilityModels
-
-
-class EventType(enum.IntEnum):
-    INVALIDEVENT = (-1,)
-    FAULTEVENT = (0,)
-    FOLDEVENT = (1,)
-    FOLIATIONSEVENT = (2,)
-    DISCONTINUITYEVENT = (3,)
-    STRATIGRAPHICLAYER = 4
-
-
-class EventRelationshipType(enum.IntEnum):
-    INVALIDTYPE = -1
-    STRATA_STRATA = 0
-    FAULT_STRATA = 1
-    FAULT_FAULT_SPLAY = 2
-    FAULT_FAULT_ABUT = 3
-    FAULT_FAULT_OVERPRINT = 4
-
-class ThickenessCalculatorType(enum.IntEnum):
-    ALPHA = 0
-    INTERPOLATED_STRUCTURE = 1
-    STRUCTURAL_POINT = 2
-    PLACEHOLDER_1 = 3
-    PLACEHOLDER_2 = 4
 
 # ###  External Accessors ### #
 
@@ -739,9 +715,9 @@ stratigraphicLayerType = numpy.dtype(
         ("group", "S120"),
         ("supergroup", "S120"),
         ("enabled", "u1"),
-        ("ThicknessMean", "<f8", (len(ThickenessCalculatorType)), ),
-        ("ThicknessMedian", "<f8", (len(ThickenessCalculatorType)), ),
-        ("ThicknessStdDev", "<f8", (len(ThickenessCalculatorType)), ),
+        ("ThicknessMean", "<f8", (len(ThicknessCalculatorType)), ),
+        ("ThicknessMedian", "<f8", (len(ThicknessCalculatorType)), ),
+        ("ThicknessStdDev", "<f8", (len(ThicknessCalculatorType)), ),
         ("colour1Red", "u1"),
         ("colour1Green", "u1"),
         ("colour1Blue", "u1"),

--- a/LoopProjectFile/LoopProjectFile.py
+++ b/LoopProjectFile/LoopProjectFile.py
@@ -34,7 +34,6 @@ import pandas
 
 import sys
 import os
-import enum
 
 import netCDF4
 from .LoopProjectFileEnums import ThicknessCalculatorType

--- a/LoopProjectFile/LoopProjectFileEnums.py
+++ b/LoopProjectFile/LoopProjectFileEnums.py
@@ -1,0 +1,27 @@
+import enum
+
+
+class EventType(enum.IntEnum):
+    INVALIDEVENT = (-1,)
+    FAULTEVENT = (0,)
+    FOLDEVENT = (1,)
+    FOLIATIONSEVENT = (2,)
+    DISCONTINUITYEVENT = (3,)
+    STRATIGRAPHICLAYER = 4
+
+
+class EventRelationshipType(enum.IntEnum):
+    INVALIDTYPE = -1
+    STRATA_STRATA = 0
+    FAULT_STRATA = 1
+    FAULT_FAULT_SPLAY = 2
+    FAULT_FAULT_ABUT = 3
+    FAULT_FAULT_OVERPRINT = 4
+
+
+class ThicknessCalculatorType(enum.IntEnum):
+    ALPHA = 0
+    INTERPOLATED_STRUCTURE = 1
+    STRUCTURAL_POINT = 2
+    PLACEHOLDER_1 = 3
+    PLACEHOLDER_2 = 4

--- a/LoopProjectFile/LoopProjectFileUtils.py
+++ b/LoopProjectFile/LoopProjectFileUtils.py
@@ -4,7 +4,7 @@ import os
 import sys
 import numpy
 import LoopProjectFile
-
+from .LoopProjectFileEnums import ThicknessCalculatorType
 
 def GetGroup(node, groupName, verbose=False):
     """
@@ -280,7 +280,12 @@ def FromCsv(loopFilename, importPath, overwrite=False):
     return "All CSV files processed successfully"
 
 
-def ElementToDataframe(loopFilename, element, loopCompoundType):
+def ElementToDataframe(
+        loopFilename,
+        element,
+        loopCompoundType,
+        startigraphicLogThickness=ThicknessCalculatorType.ALPHA
+    ):
     """
     **ElementToCsv** - Exports one element of the loop project file
     to a csv file outputFilename
@@ -293,6 +298,9 @@ def ElementToDataframe(loopFilename, element, loopCompoundType):
         The name of the element to extract
     loopCompoundType: numpy.compoundType
         The numpy data structure that the element is stored in
+    stratigraphicLogThickness: ThicknessCalculatorType
+        If the element is a stratigraphicLog which thickness calculator
+        output is used in the generic thickness field
 
     Returns
     -------
@@ -310,6 +318,8 @@ def ElementToDataframe(loopFilename, element, loopCompoundType):
                 df[name] = df[name].astype(loopCompoundType[name])
         df = df.map(lambda x: x.decode() if isinstance(x, bytes) else x)
         # df.set_index(columns[0], inplace=True)
+        if element == "stratigraphicLog":
+            df["thickness"] = df.ThicknessMedian.map(lambda x: x[startigraphicLogThickness])
         return df  # .to_csv(outputFilename)
 
 

--- a/LoopProjectFile/__init__.py
+++ b/LoopProjectFile/__init__.py
@@ -22,8 +22,6 @@ from .LoopProjectFile import (
     drillholePropertyType,
     ConvertDataFrame,
     ConvertToDataFrame,
-    EventType,
-    EventRelationshipType,
     CheckFileIsLoopProjectFile,
 )  # noqa : F401
 from .Permutations import (
@@ -33,6 +31,11 @@ from .Permutations import (
     CalcPermutation,
     checkBrokenRules,
     checkBrokenEventRules,
+)  # noqa : F401
+from .LoopProjectFileEnums import (
+    EventType,
+    EventRelationshipType,
+    ThicknessCalculatorType,
 )  # noqa : F401
 from .LoopProjectFileUtils import (
     ToCsv,


### PR DESCRIPTION
LoopStructural relies on having a single thickness value for each stratigraphic layer, this change allows for selecting which thickness median to use when requesting thicknesses but maintains access to multiple thicknesses via the usual method.

There is a subsequent change required for LoopStructural to return "ThicknessMedian" to "thickness" in LoopStrutural/modelling/input/project_file.py but it is a minor fix.